### PR TITLE
Fixed font being changed after dollar sign

### DIFF
--- a/threedicegames.ipynb
+++ b/threedicegames.ipynb
@@ -21,7 +21,7 @@
    "id": "ea3f7e0a",
    "metadata": {},
    "source": [
-    "Make sense? For example, let's say your net worth is $1000. If you roll a 1 it'll become $500. Then if you roll a 6 it'll become $750. Then if you roll a 3, the $750 will become $787.50. Each roll is cummulative! Nietzsche will roll 300 times, and you'll get to walk away with whatever is left. The question that remains is: would you play? "
+    "Make sense? For example, let's say your net worth is \$1000. If you roll a 1, it'll become \$500. Then if you roll a 6, it'll become \$750. Then if you roll a 3, the $750 will become $787.50. Each roll is cummulative! Nietzsche will roll 300 times, and you'll get to walk away with whatever is left. The question that remains is: would you play? "
    ]
   },
   {

--- a/threedicegames.ipynb
+++ b/threedicegames.ipynb
@@ -21,7 +21,7 @@
    "id": "ea3f7e0a",
    "metadata": {},
    "source": [
-    "Make sense? For example, let's say your net worth is $1000. If you roll a 1, it'll become $500. Then if you roll a 6, it'll become $750. Then if you roll a 3, the $750 will become $787.50. Each roll is cummulative! Nietzsche will roll 300 times, and you'll get to walk away with whatever is left. The question that remains is: would you play? "
+    "Make sense? For example, let's say your net worth is $1000. If you roll a 1 it'll become $500. Then if you roll a 6 it'll become $750. Then if you roll a 3, the $750 will become $787.50. Each roll is cummulative! Nietzsche will roll 300 times, and you'll get to walk away with whatever is left. The question that remains is: would you play? "
    ]
   },
   {

--- a/threedicegames.ipynb
+++ b/threedicegames.ipynb
@@ -21,7 +21,7 @@
    "id": "ea3f7e0a",
    "metadata": {},
    "source": [
-    "Make sense? For example, let's say your net worth is \$1000. If you roll a 1, it'll become \$500. Then if you roll a 6, it'll become \$750. Then if you roll a 3, the $750 will become $787.50. Each roll is cummulative! Nietzsche will roll 300 times, and you'll get to walk away with whatever is left. The question that remains is: would you play? "
+    "Make sense? For example, let's say your net worth is \\$1000. If you roll a 1, it'll become \\$500. Then if you roll a 6, it'll become \\$750. Then if you roll a 3, the $750 will become $787.50. Each roll is cummulative! Nietzsche will roll 300 times, and you'll get to walk away with whatever is left. The question that remains is: would you play? "
    ]
   },
   {

--- a/threedicegames.ipynb
+++ b/threedicegames.ipynb
@@ -21,7 +21,7 @@
    "id": "ea3f7e0a",
    "metadata": {},
    "source": [
-    "Make sense? For example, let's say your net worth is \\$1000. If you roll a 1, it'll become \\$500. Then if you roll a 6, it'll become \\$750. Then if you roll a 3, the $750 will become $787.50. Each roll is cummulative! Nietzsche will roll 300 times, and you'll get to walk away with whatever is left. The question that remains is: would you play? "
+    "Make sense? For example, let's say your net worth is \\$1000. If you roll a 1, it'll become \\$500. Then if you roll a 6, it'll become \\$750. Then if you roll a 3, the \\$750 will become \\$787.50. Each roll is cummulative! Nietzsche will roll 300 times, and you'll get to walk away with whatever is left. The question that remains is: would you play? "
    ]
   },
   {


### PR DESCRIPTION
Closes #1 , looks $ changes the font in jupyter notebooks. I'm not familiar with them, but based on this [https://stackoverflow.com/questions/16089089/escaping-dollar-sign-in-ipython-notebook](https://stackoverflow.com/questions/16089089/escaping-dollar-sign-in-ipython-notebook), it looks like \\\ works as an escape for the $.